### PR TITLE
priorityClassName specified in the wrong place

### DIFF
--- a/FFCDemoPaymentService/FFCDemoPaymentService.csproj
+++ b/FFCDemoPaymentService/FFCDemoPaymentService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>2.0.4</Version>
+    <Version>2.0.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/helm/ffc-demo-payment-service-core/templates/deployment.yaml
+++ b/helm/ffc-demo-payment-service-core/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels: {{ include "ffc-demo.labels" . | trimSuffix "\n" | indent 2 }}
   namespace: {{ quote .Values.namespace }}
 spec:
-  priorityClassName: {{ quote .Values.container.priorityClassName }}
   replicas: {{ .Values.replicaCount }}
   minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
@@ -19,6 +18,7 @@ spec:
       annotations:
         redeployOnChange: {{ quote .Values.container.redeployOnChange }}
     spec:
+      priorityClassName: {{ quote .Values.container.priorityClassName }}
       {{- if .Values.serviceAccount.roleArn }}
       serviceAccountName: {{ quote .Values.serviceAccount.name }}
       {{- end }}


### PR DESCRIPTION
Helm 3 has highlighed an issue where priorityClassName is specified in
the spec of the deployment rather than the pod further down.