### PR TITLE
Allow diagnostics in container to allow debugging

### DIFF
--- a/FFCDemoPaymentService/FFCDemoPaymentService.csproj
+++ b/FFCDemoPaymentService/FFCDemoPaymentService.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ The following environment variables are required by the application container. V
 
 | Name                                | Description                  | Required | Default     | Valid                       | Notes |
 |-------------------------------------|------------------------------|:--------:|-------------|-----------------------------|-------|
-| ConnectionStrings__DefaultConnection| Database connection string   | yes      |             |                             |       |
-| COMPlus_EnableDiagnostics           | Enable COM diagnostics       | yes      |             |                             | Should be set to 0 when running in Kubernetes read only file system      |
+| ConnectionStrings__DefaultConnection| Database connection string   | yes      |             |                             |       | read only file system      |
 | Messaging__ScheduleQueueName        | Schedule queue name          | no       | schedule    |                             |       |
 | Messaging__ScheduleQueueEndpoint    | Schedule queue endpoint      | no       | http://localhost:9324 |                   |       |
 | Messaging__ScheduleQueueUrl         | Schedule queue url           | no       | http://localhost:9324/queue/schedule |    |       |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,7 @@ services:
     container_name: ffc-demo-payment-service-core
     depends_on:
       - ffc-demo-payment-core-postgres
-    environment:
-      COMPlus_EnableDiagnostics: 0
+    environment:      
       ConnectionStrings__DefaultConnection: "Server=ffc-demo-payment-core-postgres;Port=5432;Database=ffc_demo_payments;User Id=postgres;Password=ppp;"
 
   ffc-demo-payment-core-postgres:


### PR DESCRIPTION
`COMPlus_EnableDiagnostics` environment variable removed from Docker Compose as not needed outside Kubernetes.  It's presence is also preventing remote debugging locally.

https://eaflood.atlassian.net/browse/PSD-525